### PR TITLE
Avoid overriding --dist-version

### DIFF
--- a/configure
+++ b/configure
@@ -3,7 +3,6 @@
 --with-nmcli=yes
 --disable-json-validation
 --with-config-plugins-default=keyfile
---with-dist-version="Clear Linux Software for Intel Architecture"
 --with-dhclient=/usr/bin/dhclient
 --with-session-tracking=systemd
 --with-suspend-resume=systemd

--- a/configure32
+++ b/configure32
@@ -3,7 +3,6 @@
 --with-nmcli=no
 --disable-json-validation
 --with-config-plugins-default=keyfile
---with-dist-version="Clear Linux Software for Intel Architecture"
 --with-dhclient=/usr/bin/dhclient
 --with-session-tracking=systemd
 --with-suspend-resume=systemd


### PR DESCRIPTION
Replacing the version with something that very obviously is not a
version breaks the version queries (e.g. "nmcli --version").

The option is intended for distributions that wish to include their own
release number in the version string. If you can't do that please just
use the defaults.